### PR TITLE
Add listen interface as param

### DIFF
--- a/cmd/dvara/main.go
+++ b/cmd/dvara/main.go
@@ -26,7 +26,7 @@ func Main() error {
 	addrs := flag.String("addrs", "localhost:27017", "comma separated list of mongo addresses")
 	clientIdleTimeout := flag.Duration("client_idle_timeout", 60*time.Minute, "idle timeout for client connections")
 	getLastErrorTimeout := flag.Duration("get_last_error_timeout", time.Minute, "timeout for getLastError pinning")
-	listenAddr := flag.String("listen", " 127.0.0.1", "address for listening, for example, 127.0.0.1 for reachable only from the same machine, or 0.0.0.0 for reachable from other machines")
+	listenAddr := flag.String("listen", "127.0.0.1", "address for listening, for example, 127.0.0.1 for reachable only from the same machine, or 0.0.0.0 for reachable from other machines")
 	maxConnections := flag.Uint("max_connections", 100, "maximum number of connections per mongo")
 	maxPerClientConnections := flag.Uint("max_per_client_connections", 1, "maximum number of connections from a single client")
 	messageTimeout := flag.Duration("message_timeout", 2*time.Minute, "timeout for one message to be proxied")

--- a/cmd/dvara/main.go
+++ b/cmd/dvara/main.go
@@ -26,6 +26,7 @@ func Main() error {
 	addrs := flag.String("addrs", "localhost:27017", "comma separated list of mongo addresses")
 	clientIdleTimeout := flag.Duration("client_idle_timeout", 60*time.Minute, "idle timeout for client connections")
 	getLastErrorTimeout := flag.Duration("get_last_error_timeout", time.Minute, "timeout for getLastError pinning")
+	listenAddr := flag.String("listen", " 127.0.0.1", "address for listening, for example, 127.0.0.1 for reachable only from the same machine, or 0.0.0.0 for reachable from other machines")
 	maxConnections := flag.Uint("max_connections", 100, "maximum number of connections per mongo")
 	maxPerClientConnections := flag.Uint("max_per_client_connections", 1, "maximum number of connections from a single client")
 	messageTimeout := flag.Duration("message_timeout", 2*time.Minute, "timeout for one message to be proxied")
@@ -42,6 +43,7 @@ func Main() error {
 		Addrs:                   *addrs,
 		ClientIdleTimeout:       *clientIdleTimeout,
 		GetLastErrorTimeout:     *getLastErrorTimeout,
+		ListenAddr:              *listenAddr,
 		MaxConnections:          *maxConnections,
 		MaxPerClientConnections: *maxPerClientConnections,
 		MessageTimeout:          *messageTimeout,

--- a/common_test.go
+++ b/common_test.go
@@ -43,6 +43,7 @@ type Harness struct {
 func newHarnessInternal(url string, s stopper, t testing.TB) *Harness {
 	replicaSet := ReplicaSet{
 		Addrs:                   url,
+		ListenAddr:              "",
 		PortStart:               2000,
 		PortEnd:                 3000,
 		MaxConnections:          5,

--- a/replica_set.go
+++ b/replica_set.go
@@ -60,6 +60,10 @@ type ReplicaSet struct {
 	PortStart int
 	PortEnd   int
 
+	// Where to listen for clients.
+	// "0.0.0.0" means public service, "127.0.0.1" means localhost only.
+	ListenAddr string
+
 	// Maximum number of connections that will be established to each mongo node.
 	MaxConnections uint
 
@@ -302,7 +306,7 @@ func (r *ReplicaSet) proxyHostname() string {
 
 func (r *ReplicaSet) newListener() (net.Listener, error) {
 	for i := r.PortStart; i <= r.PortEnd; i++ {
-		listener, err := net.Listen("tcp", fmt.Sprintf(":%d", i))
+		listener, err := net.Listen("tcp", fmt.Sprintf("%s:%d", r.ListenAddr, i))
 		if err == nil {
 			return listener, nil
 		}


### PR DESCRIPTION
Make it possible to specify the proxy listens only locally, and not for connections outside the box.

Previous to this PR, proxy listened on 0.0.0.0 which is accessible, though not secure.
