### PR TITLE
Add logging prefix to dvara startup.

### DIFF
--- a/cmd/dvara/logger.go
+++ b/cmd/dvara/logger.go
@@ -6,6 +6,10 @@ import "log"
 // placeholder until we can open source our logger.
 type stdLogger struct{}
 
+func (l *stdLogger) SetPrefix(prefix string) {
+	log.SetPrefix(prefix)
+}
+
 func (l *stdLogger) Error(args ...interface{})                 { log.Printf("ERROR:%s", args...) }
 func (l *stdLogger) Errorf(format string, args ...interface{}) { log.Printf("ERROR:"+format, args...) }
 func (l *stdLogger) Warn(args ...interface{})                  { log.Printf("WARN:%s", args...) }

--- a/cmd/dvara/logger.go
+++ b/cmd/dvara/logger.go
@@ -4,17 +4,27 @@ import "log"
 
 // stdLogger provides a logger backed by the standard library logger. This is a
 // placeholder until we can open source our logger.
-type stdLogger struct{}
-
-func (l *stdLogger) SetPrefix(prefix string) {
-	log.SetPrefix(prefix)
+type stdLogger struct {
+	LogPrefix string
 }
 
-func (l *stdLogger) Error(args ...interface{})                 { log.Printf("ERROR:%s", args...) }
-func (l *stdLogger) Errorf(format string, args ...interface{}) { log.Printf("ERROR:"+format, args...) }
-func (l *stdLogger) Warn(args ...interface{})                  { log.Printf("WARN:%s", args...) }
-func (l *stdLogger) Warnf(format string, args ...interface{})  { log.Printf("WARN:"+format, args...) }
-func (l *stdLogger) Info(args ...interface{})                  { log.Printf("INFO:%s", args...) }
-func (l *stdLogger) Infof(format string, args ...interface{})  { log.Printf("INFO:"+format, args...) }
-func (l *stdLogger) Debug(args ...interface{})                 { log.Printf("DEBUG:%s", args...) }
-func (l *stdLogger) Debugf(format string, args ...interface{}) { log.Printf("DEBUG:"+format, args...) }
+func (l *stdLogger) prepend(level string, format string) string {
+	return level + l.LogPrefix + format
+}
+
+func (l *stdLogger) Error(args ...interface{}) { log.Printf(l.prepend("ERROR:", "%s"), args...) }
+func (l *stdLogger) Errorf(format string, args ...interface{}) {
+	log.Printf(l.prepend("ERROR:", format), args...)
+}
+func (l *stdLogger) Warn(args ...interface{}) { log.Printf(l.prepend("WARN:", "%s"), args...) }
+func (l *stdLogger) Warnf(format string, args ...interface{}) {
+	log.Printf(l.prepend("WARN:", format), args...)
+}
+func (l *stdLogger) Info(args ...interface{}) { log.Printf(l.prepend("INFO:", "%s"), args...) }
+func (l *stdLogger) Infof(format string, args ...interface{}) {
+	log.Printf(l.prepend("INFO:", format), args...)
+}
+func (l *stdLogger) Debug(args ...interface{}) { log.Printf(l.prepend("DEBUG:", "%s"), args...) }
+func (l *stdLogger) Debugf(format string, args ...interface{}) {
+	log.Printf(l.prepend("DEBUG:", format), args...)
+}

--- a/cmd/dvara/main.go
+++ b/cmd/dvara/main.go
@@ -57,8 +57,7 @@ func Main() error {
 		Username:                *username,
 	}
 
-	var log stdLogger
-	log.SetPrefix(*logPrefix)
+	log := stdLogger{*logPrefix}
 	var graph inject.Graph
 	err := graph.Provide(
 		&inject.Object{Value: &log},

--- a/cmd/dvara/main.go
+++ b/cmd/dvara/main.go
@@ -36,10 +36,10 @@ func Main() error {
 	serverIdleTimeout := flag.Duration("server_idle_timeout", 60*time.Minute, "duration after which a server connection will be considered idle")
 	username := flag.String("username", "", "mongo db username")
 	metricsAddress := flag.String("metrics", "127.0.0.1:8125", "UDP address to send metrics to datadog, default is 127.0.0.1:8125")
-	logPrefix := flag.String("log_prefix", "", "Log prefix, default is empty")
+	replicaName := flag.String("replica_name", "", "Replica name, used in metrics and logging, default is empty")
 
 	flag.Parse()
-	statsClient := NewDataDogStatsDClient(*metricsAddress)
+	statsClient := NewDataDogStatsDClient(*metricsAddress, *replicaName)
 
 	replicaSet := dvara.ReplicaSet{
 		Addrs:                   *addrs,
@@ -57,7 +57,7 @@ func Main() error {
 		Username:                *username,
 	}
 
-	log := stdLogger{*logPrefix}
+	log := stdLogger{*replicaName}
 	var graph inject.Graph
 	err := graph.Provide(
 		&inject.Object{Value: &log},

--- a/cmd/dvara/main.go
+++ b/cmd/dvara/main.go
@@ -36,6 +36,7 @@ func Main() error {
 	serverIdleTimeout := flag.Duration("server_idle_timeout", 60*time.Minute, "duration after which a server connection will be considered idle")
 	username := flag.String("username", "", "mongo db username")
 	metricsAddress := flag.String("metrics", "127.0.0.1:8125", "UDP address to send metrics to datadog, default is 127.0.0.1:8125")
+	logPrefix := flag.String("log_prefix", "", "Log prefix, default is empty")
 
 	flag.Parse()
 	statsClient := NewDataDogStatsDClient(*metricsAddress)
@@ -57,6 +58,7 @@ func Main() error {
 	}
 
 	var log stdLogger
+	log.SetPrefix(*logPrefix)
 	var graph inject.Graph
 	err := graph.Provide(
 		&inject.Object{Value: &log},


### PR DESCRIPTION
Since multiple dvara instances are running, this prefix will be used to tell which dvara is logging to shared log.

```
➜  dvara git:(barisa/add-logging-prefic) ✗ go run   main.go logger.go data_dog.go -max_per_client_connections=100 -log_prefix=c2\
2015/11/09 14:00:54 DEBUG:c2 starting *dvara.ReplicaSet
2015/11/09 14:00:59 ERROR:c2 ignoring failure against address localhost:27017: no reachable servers
could not connect to any provided addresses: [localhost:27017]
exit status 1
```
