### PR TITLE
Add extra space in logprefix

### DIFF
--- a/cmd/dvara/main.go
+++ b/cmd/dvara/main.go
@@ -57,7 +57,8 @@ func Main() error {
 		Username:                *username,
 	}
 
-	log := stdLogger{*replicaName}
+	// Extra space in logger, as word boundary
+	log := stdLogger{*replicaName + " "}
 	var graph inject.Graph
 	err := graph.Provide(
 		&inject.Object{Value: &log},


### PR DESCRIPTION
, so that CLI user does not have to encode space in bash command
