### PR TITLE
Adding Proxy Rewrite Support for `passive` hosts

### DIFF
--- a/response_rewriter_test.go
+++ b/response_rewriter_test.go
@@ -295,6 +295,55 @@ func TestIsMasterResponseRewriterSuccess(t *testing.T) {
 		"primary": "2",
 		"foo":     "bar",
 	}
+
+	r := &IsMasterResponseRewriter{
+		Log:                 nopLogger{},
+		ProxyMapper:         proxyMapper,
+		ReplicaStateCompare: fakeReplicaStateCompare{sameIM: true, sameRS: true},
+		ReplyRW: &ReplyRW{
+			Log: nopLogger{},
+		},
+	}
+
+	var client bytes.Buffer
+	if err := r.Rewrite(&client, fakeSingleDocReply(in)); err != nil {
+		t.Fatal(err)
+	}
+	actualOut := bson.M{}
+	doc := client.Bytes()[headerLen+len(emptyPrefix):]
+	if err := bson.Unmarshal(doc, &actualOut); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(out, actualOut) {
+		spew.Dump(out)
+		spew.Dump(actualOut)
+		t.Fatal("did not get expected output")
+	}
+}
+
+func TestIsMasterResponseRewriterSuccessWithPassives(t *testing.T) {
+	proxyMapper := fakeProxyMapper{
+		m: map[string]string{
+			"a": "1",
+			"b": "2",
+			"c": "3",
+		},
+	}
+	in := bson.M{
+		"hosts":    []interface{}{"a", "b", "c"},
+		"me":       "a",
+		"primary":  "b",
+		"foo":      "bar",
+		"passives": []interface{}{"a"},
+	}
+	out := bson.M{
+		"hosts":    []interface{}{"1", "2", "3"},
+		"me":       "1",
+		"primary":  "2",
+		"foo":      "bar",
+		"passives": []interface{}{"1"},
+	}
+
 	r := &IsMasterResponseRewriter{
 		Log:                 nopLogger{},
 		ProxyMapper:         proxyMapper,


### PR DESCRIPTION
Currently dvara does not rewrite passive hosts, this means that dvara
can report the wrong state, and then apps that talk to dvara try to
connect directly instead of through dvara
