### PR TITLE
Datadog does not like raw numbers as tags.

### DIFF
--- a/cmd/dvara/main.go
+++ b/cmd/dvara/main.go
@@ -42,7 +42,7 @@ func Main() error {
 	failedHealthCheckThreshold := flag.Uint("failedhealthcheckthreshold", 3, "How many failed checks before a restart")
 
 	flag.Parse()
-	statsClient := NewDataDogStatsDClient(*metricsAddress, *replicaName)
+	statsClient := NewDataDogStatsDClient(*metricsAddress, "replica:"+*replicaName)
 
 	replicaSet := dvara.ReplicaSet{
 		Addrs:                   *addrs,


### PR DESCRIPTION
Setting key value, replica:99 as example instead
