### PR TITLE
Barisa/fix stale auth connections

### DIFF
--- a/healthcheck.go
+++ b/healthcheck.go
@@ -105,8 +105,8 @@ func (r *ReplicaSet) runCheck(portStart int, errChan chan<- error) {
 	if err == nil {
 		defer session.Close()
 		session.SetMode(mgo.PrimaryPreferred, true)
-		_, isMasterErr := isMaster(session)
-		err = isMasterErr
+		_, replStatusErr := replSetGetStatus(session)
+		err = replStatusErr
 	}
 	select {
 	case errChan <- err:

--- a/proxy.go
+++ b/proxy.go
@@ -284,7 +284,7 @@ func (p *Proxy) clientServeLoop(c net.Conn) {
 			err := p.proxyMessage(h, c, serverConn, &lastError)
 			if err != nil {
 				p.serverPool.Discard(serverConn)
-				p.Log.Error(err)
+				p.Log.Errorf("Proxy message failed %s ", err)
 				stats.BumpSum(p.stats, "message.proxy.error", 1)
 				if ne, ok := err.(net.Error); ok && ne.Timeout() {
 					stats.BumpSum(p.stats, "message.proxy.timeout", 1)

--- a/response_rewriter_test.go
+++ b/response_rewriter_test.go
@@ -343,6 +343,31 @@ func TestReplSetGetStatusResponseRewriterSuccess(t *testing.T) {
 	}
 }
 
+func TestReplSetGetStatusResponseRewriterAuthFailure(t *testing.T) {
+	proxyMapper := fakeProxyMapper{
+		m: map[string]string{
+			"a": "1",
+			"b": "2",
+			"c": "3",
+		},
+	}
+	in := bson.M{
+		"code": 13,
+	}
+	r := &ReplSetGetStatusResponseRewriter{
+		Log:         nopLogger{},
+		ProxyMapper: proxyMapper,
+		ReplyRW: &ReplyRW{
+			Log: nopLogger{},
+		},
+	}
+
+	var client bytes.Buffer
+	if err := r.Rewrite(&client, fakeSingleDocReply(in)); err == nil {
+		t.Fatal("Rewrite did not fail, though authentication failed")
+	}
+}
+
 func TestProxyQuery(t *testing.T) {
 	t.Parallel()
 	var p ProxyQuery


### PR DESCRIPTION
Calling getReplStatus will make sure the dvara pool of connection is checked for auth failures.

If server gives connections in LIFO way, there is a chance that all bad auth connections will never be cleaned out.
There is an option to read every request, and inspect it; so far only isMaster and GetReplStatus are inspected and rewritten.
There is a chance that doing that will increase dvara request latency.
