### PR TITLE
Remove debug logging from mongo socket

### DIFF
--- a/mongo_socket.go
+++ b/mongo_socket.go
@@ -83,7 +83,6 @@ func (socket *mongoSocket) Query(op *queryOp) (err error) {
 	p := make([]byte, 36) // 16 from header + 20 from OP_REPLY fixed fields
 	fill(socket.conn, p)
 
-	fmt.Printf("%d", getInt32(p, 32))
 	reply := replyOp{
 		flags:     uint32(getInt32(p, 16)),
 		cursorId:  getInt64(p, 20),


### PR DESCRIPTION
This prints a single character without a trailing newline, which makes the logs harder to scan.
