### PR TITLE
Rc/pass replica set name to dvara

### DIFF
--- a/cmd/dvara/main.go
+++ b/cmd/dvara/main.go
@@ -66,6 +66,16 @@ func Main() error {
 	corelog.SetStandardFields("replicaset", *replicaName)
 	corelog.UseTimestamp(true)
 
+	// Log command line args
+	startupOptions := []interface{} {}
+	flag.CommandLine.VisitAll(func(flag *flag.Flag) {
+		if flag.Name != "password" {
+			startupOptions = append(startupOptions, flag.Name, flag.Value.String())
+		}
+		corelog.LogInfo(flag.Name, flag.Value.String())
+	})
+	corelog.LogInfoMessage("starting with command line arguments", startupOptions...)
+
 	// Wrapper for inject
 	log := Logger{}
 

--- a/cmd/dvara/main.go
+++ b/cmd/dvara/main.go
@@ -38,6 +38,7 @@ func Main() error {
 	username := flag.String("username", "", "mongo db username")
 	metricsAddress := flag.String("metrics", "127.0.0.1:8125", "UDP address to send metrics to datadog, default is 127.0.0.1:8125")
 	replicaName := flag.String("replica_name", "", "Replica name, used in metrics and logging, default is empty")
+	replicaSetName := flag.String("replica_set_name", "", "Replica set name, used to filter hosts runnning other replica sets")
 	healthCheckInterval := flag.Duration("healthcheckinterval", 5*time.Second, "How often to run the health check")
 	failedHealthCheckThreshold := flag.Uint("failedhealthcheckthreshold", 3, "How many failed checks before a restart")
 
@@ -58,6 +59,7 @@ func Main() error {
 		ServerClosePoolSize:     *serverClosePoolSize,
 		ServerIdleTimeout:       *serverIdleTimeout,
 		Username:                *username,
+		Name:                    *replicaSetName,
 	}
 	stateManager := dvara.NewStateManager(&replicaSet)
 

--- a/healthcheck_test.go
+++ b/healthcheck_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 	"time"
+	"github.com/facebookgo/mgotest"
 )
 
 type FakeReplicaSet struct {
@@ -58,4 +59,25 @@ func TestEnsureRestartIsNotCalled(t *testing.T) {
 		t.Fatalf("Restart function not called :( %s", frs)
 	}
 
+}
+
+func TestChecksWithReplicaSets(t *testing.T) {
+	t.Parallel()
+	standalone := mgotest.NewStartedServer(t)
+	defer standalone.Stop()
+	rs := mgotest.NewReplicaSet(3, t)
+	defer rs.Stop()
+
+	if err := checkReplSetStatus(rs.Addrs(), "rs"); err != nil {
+		t.Error("check should pass if all members are in the replica set:", err)
+	}
+	if err := checkReplSetStatus([]string{standalone.URL()}, "rs"); err == nil {
+		t.Error("expected failure if single server running in standalone")
+	}
+	if err := checkReplSetStatus(append(rs.Addrs(), standalone.URL()), "rs"); err != nil {
+		t.Error("check should ignore standalone if there are other healthy members:", err)
+	}
+	if err := checkReplSetStatus(rs.Addrs(), "rs-alt"); err == nil {
+		t.Error("check should fail if members are in a different replica set")
+	}
 }


### PR DESCRIPTION
This considers healthchecks only for hosts that are in the replica set

If no replica_set_name is passed on the command line, this disables the feature.

The rollout plan should be to rollout the dvara change, and then make the corresponding change in the app to pass the new argument.