### PR TITLE
failfast on connection refused

### DIFF
--- a/rs_state.go
+++ b/rs_state.go
@@ -33,6 +33,7 @@ func NewReplicaSetState(username, password, addr string) (*ReplicaSetState, erro
 		Username: username,
 		Password: password,
 		Direct:   true,
+		FailFast: true,
 		Timeout:  TIMEOUT,
 	}
 	session, err := mgo.DialWithInfo(info)


### PR DESCRIPTION
When determining replica set state, fail fast, rather than retrying up to 1.5 seconds.

This reduces the time taken to synchronize replica set state if the seed list contains hosts that are not available.