### PR TITLE
Rc/do not crash on missing member

### DIFF
--- a/cmd/dvara/main.go
+++ b/cmd/dvara/main.go
@@ -73,7 +73,6 @@ func Main() error {
 		if flag.Name != "password" {
 			startupOptions = append(startupOptions, flag.Name, flag.Value.String())
 		}
-		corelog.LogInfo(flag.Name, flag.Value.String())
 	})
 	corelog.LogInfoMessage("starting with command line arguments", startupOptions...)
 

--- a/state_manager.go
+++ b/state_manager.go
@@ -195,7 +195,9 @@ func (manager *StateManager) getComparison(oldResp, newResp *replSetGetStatusRes
 	}
 
 	for _, m := range oldResp.Members {
-		comparison.ExtraMembers[m.Name] = manager.findProxyForMember(m)
+		if proxy, ok := manager.findProxyForMember(m); ok {
+			comparison.ExtraMembers[m.Name] = proxy
+		}
 	}
 
 	for _, m := range newResp.Members {
@@ -280,10 +282,11 @@ func (manager *StateManager) stopProxy(proxy *Proxy) {
 	}
 }
 
-func (manager *StateManager) findProxyForMember(member statusMember) *Proxy {
+func (manager *StateManager) findProxyForMember(member statusMember) (*Proxy, bool) {
 	proxyName, ok := manager.realToProxy[member.Name]
 	if !ok {
-		return nil
+		return nil, false
 	}
-	return manager.proxies[proxyName]
+	proxy, ok := manager.proxies[proxyName]
+	return proxy, ok
 }

--- a/state_manager.go
+++ b/state_manager.go
@@ -71,8 +71,7 @@ func (manager *StateManager) KeepSynchronized(syncChan chan struct{}) {
 
 // Get new state for a replica set, and synchronize internal state.
 func (manager *StateManager) Synchronize() {
-	t := manager.replicaSet.Stats.BumpTime("replica.manager.time")
-	defer t.End()
+	defer manager.replicaSet.Stats.BumpTime("replica.manager.time").End()
 
 	manager.RLock()
 	newState, err := manager.generateReplicaSetState()
@@ -92,8 +91,7 @@ func (manager *StateManager) Synchronize() {
 	}
 	manager.RUnlock() // all reads done
 
-	lockedTime := manager.replicaSet.Stats.BumpTime("replica.manager.time.locked")
-	defer lockedTime.End()
+	defer manager.replicaSet.Stats.BumpTime("replica.manager.time.locked").End()
 
 	manager.Lock()
 	defer manager.Unlock()

--- a/state_manager_test.go
+++ b/state_manager_test.go
@@ -8,6 +8,7 @@ import (
 
 func TestManagerFindsMissingExtraMembers(t *testing.T) {
 	manager := newManager()
+	manager.addProxies("a", "b")
 
 	comparison, _ := manager.getComparison(getStatusResponse("a", "b"), getStatusResponse("a", "c"))
 	if _, ok := comparison.ExtraMembers["b"]; !ok {
@@ -37,6 +38,15 @@ func TestManagerAddsAndRemovesProxies(t *testing.T) {
 	}
 	if _, ok := manager.proxies[manager.realToProxy["mongoC"]]; !ok {
 		t.Fatal("proxyC was not added")
+	}
+}
+
+func TestManagerWithMissingMembersInCurrentState(t *testing.T) {
+	manager := newManager()
+	manager.addProxies("mongoA")
+	comparison, _ := manager.getComparison(getStatusResponse("mongoA", "mongoB"), getStatusResponse("mongoA", "mongoC"))
+	if _, ok := comparison.ExtraMembers["mongoB"]; ok {
+		t.Fatal("mongoB is not currently running")
 	}
 }
 


### PR DESCRIPTION
Dvara should not crash when it cannot find a proxy to stop when comparing current replica set state to the desired state.

Some proxies may be missing because, for example, dvara does not run proxies for arbiters.