### PR TITLE
Reduce high volume mongoproxy metrics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: go
-script: go test $(go list ./... | grep -v vendor/) -tags=integration
+script: travis_wait 20 go test $(go list ./... | grep -v vendor/) -tags=integration
 go:
   - 1.6.1

--- a/proxy.go
+++ b/proxy.go
@@ -163,7 +163,6 @@ func (p *Proxy) proxyMessage(
 	// OpQuery may need to be transformed and need special handling in order to
 	// make the proxy transparent.
 	if h.OpCode == OpQuery {
-		stats.BumpSum(p.stats, "message.with.response", 1)
 		return p.ReplicaSet.ProxyQuery.Proxy(h, client, server, lastError)
 	}
 
@@ -187,7 +186,6 @@ func (p *Proxy) proxyMessage(
 
 	// For Ops with responses we proxy the raw response message over.
 	if h.OpCode.HasResponse() {
-		stats.BumpSum(p.stats, "message.with.response", 1)
 		if err := copyMessage(client, server); err != nil {
 			corelog.LogError("error", err)
 			return err
@@ -335,7 +333,6 @@ func (p *Proxy) gleClientReadHeader(c net.Conn) (*messageHeader, error) {
 }
 
 func (p *Proxy) clientReadHeader(c net.Conn, timeout time.Duration) (*messageHeader, error) {
-	t := stats.BumpTime(p.stats, "client.read.header.time")
 	type headerError struct {
 		header *messageHeader
 		error  error
@@ -362,7 +359,6 @@ func (p *Proxy) clientReadHeader(c net.Conn, timeout time.Duration) (*messageHea
 
 	// Successfully read a header.
 	if response.error == nil {
-		t.End()
 		return response.header, nil
 	}
 

--- a/rpool.go
+++ b/rpool.go
@@ -231,7 +231,6 @@ func (p *Pool) manage() {
 				r <- c.resource
 				resources = resources[:cl-1]
 				out++
-				stats.BumpSum(p.Stats, "acquire.pool", 1)
 				continue
 			}
 


### PR DESCRIPTION
These include

- `client.read.header.time`
- `server.pool.acquire.pool`
- `message.with.response`

These are currently one of our highest emitting metrics,
on some of our highest volume fleets.

If we don't find these useful anymore, would be nice
stop capturing these.